### PR TITLE
feat: include decorations when exporting schedule

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,7 +42,7 @@ export default function App(){
     return getDefaultEvents()
   })
 
-  const calendarWrapRef = useRef(null)
+  const exportRef = useRef(null)
   const colsRef = useRef({}) // map day -> ref to column
 
   // Agregar materia
@@ -85,7 +85,7 @@ export default function App(){
 
   // Exportar a PNG
   const onExport = async () => {
-    const wrap = calendarWrapRef.current
+    const wrap = exportRef.current
     if (!wrap) {
       alert('No se pudo encontrar el calendario para exportar.')
       return
@@ -159,7 +159,6 @@ export default function App(){
 
   return (
     <>
-      <CuteDecorations />
       <Header onExport={onExport} onClear={onClear} onRestoreDefaults={onRestoreDefaults} />
 
       <main className="grid grid-cols-[360px_1fr] max-lg:grid-cols-1 gap-6 p-6 max-w-6xl w-full mx-auto relative z-[5] mt-12">
@@ -179,12 +178,22 @@ export default function App(){
           onAdd={onAdd}
         />
 
-        <Calendar
-          events={events}
-          colsRef={colsRef}
-          calendarWrapRef={calendarWrapRef}
-          onDeleteEvent={onDeleteEvent}
-        />
+        <div
+          ref={exportRef}
+          className="relative p-6 flex items-center justify-center"
+          style={{
+            backgroundColor: '#f0f9ff',
+            backgroundImage: `linear-gradient(#dbeafe 1px, transparent 1px), linear-gradient(90deg, #dbeafe 1px, transparent 1px)`,
+            backgroundSize: '40px 40px'
+          }}
+        >
+          <Calendar
+            events={events}
+            colsRef={colsRef}
+            onDeleteEvent={onDeleteEvent}
+          />
+          <CuteDecorations />
+        </div>
       </main>
     </>
   )

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -14,7 +14,7 @@ const days = [
   { value: 5, label: 'Viernes' },
 ]
 
-export default function Calendar({ events, colsRef, calendarWrapRef, onDeleteEvent }) {
+export default function Calendar({ events, colsRef, onDeleteEvent }) {
   const hours = useMemo(() => {
     return ['7:00', '8:00', '9:00', '10:00', '11:00', '11:30', '12:30', '13:30']
   }, [])
@@ -31,9 +31,8 @@ export default function Calendar({ events, colsRef, calendarWrapRef, onDeleteEve
   }, [events])
 
   return (
-    <section 
-      className="bg-white border-4 border-blue-300 rounded-3xl overflow-hidden relative shadow-2xl cute-calendar" 
-      ref={calendarWrapRef} 
+    <section
+      className="bg-white border-4 border-blue-300 rounded-3xl overflow-visible relative shadow-2xl cute-calendar"
       aria-label="Horario Escolar"
       style={{
         background: 'linear-gradient(135deg, #ffffff 0%, #f0f9ff 100%)',
@@ -59,7 +58,7 @@ export default function Calendar({ events, colsRef, calendarWrapRef, onDeleteEve
       </div>
 
       {/* Calendar border decorations */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+      <div className="absolute inset-0 pointer-events-none overflow-visible">
         {/* Top border emojis */}
         <div className="absolute -top-4 left-16 text-3xl animate-bounce animation-delay-1000 transform -rotate-12">📝</div>
         <div className="absolute -top-6 left-32 text-2xl animate-bounce animation-delay-1500 transform rotate-12">🖍️</div>

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@ body {
 
 /* Cute decorative elements */
 .cute-decoration {
-  position: fixed;
+  position: absolute;
   pointer-events: none;
   z-index: 1;
   font-size: 2rem;


### PR DESCRIPTION
## Summary
- export a wrapper with grid background and cute decorations
- position decorations absolutely so they render in downloads
- allow border emojis to overflow the calendar

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b20d52687083219fd54cb09460de6b